### PR TITLE
Promote noeq Variants in SplayTree.ml

### DIFF
--- a/Scratch.ml
+++ b/Scratch.ml
@@ -16,9 +16,11 @@ empty_2 t = (empty_1 t)
 empty_3 ∷ Tree α → Bool
 empty_3 t = (let s = t in (Tree.empty s))
 
-same_root ∷ (Eq α, Eq (Tree α)) ⇒ Tree α ⨯ Tree α → Bool
+same_root ∷ Eq α ⇒ Tree α ⨯ Tree α → Bool
 same_root t1 t2 = match t1 with
-  | leaf → (if t2 == leaf then true else false)
+  | leaf → match t2 with
+    | leaf → true
+    | (t2l, t2x, t2r) → false
   | (lx, x, rx) → match t2 with
     | leaf → false
     | (ly, y, ry) → (if y == x then true else false)
@@ -31,7 +33,7 @@ empty_4 t1 t2 = (Bool.or (Tree.empty t1) (Tree.empty t2))
  *
  *   same_root_obviously t | log(|t| + 2) + log(2 · |t| + 2) + 1 → 0
  *)
-same_root_obviously ∷ (Eq α, Eq (Tree α)) ⇒ Tree α → Bool
+same_root_obviously ∷ Eq α ⇒ Tree α → Bool
 same_root_obviously t = (same_root t t)
 
 first_nonempty_and_second_empty ∷ Tree α ⨯ Tree β → Bool

--- a/SplayTree.ml
+++ b/SplayTree.ml
@@ -1,5 +1,9 @@
-splay ∷ (Ord α, Eq (Tree α)) ⇒ α ⨯ Tree α → Tree α
-splay a t = match t with
+(* This variant of splay does not type anymore as of 2020-04-16
+ * (type constraints).
+ *)
+(*
+splay_eq ∷ (Ord α, Eq (Tree α)) ⇒ α ⨯ Tree α → Tree α
+splay_eq a t = match t with
   | leaf        → leaf
   | (cl, c, cr) → if a == c
     then (cl, c, cr)
@@ -11,12 +15,12 @@ splay a t = match t with
           else if a < b
             then if bl == leaf
               then (bl, b, (br, c, cr))
-              else match splay a bl with
+              else match splay_eq a bl with
                 | leaf          → leaf (* TODO: undefined *)
                 | (al, a', ar) → (al, a', (ar, b, (br, c, cr)))
             else if br == leaf
               then (bl, b, (br, c, cr))
-              else match splay a br with
+              else match splay_eq a br with
                 | leaf          → leaf (* TODO: undefined *)
                 | (al, a', ar) → ((bl, b, al), a', (ar, c, cr))
       else match cr with
@@ -26,17 +30,18 @@ splay a t = match t with
           else if a < b
             then if bl == leaf
               then ((cl, c, bl), b, br)
-              else match splay a bl with
+              else match splay_eq a bl with
                 | leaf          → leaf (* TODO: undefined *)
                 | (al, a', ar) → ((cl, c, al), a', (ar, b, br))
             else if br == leaf
               then ((cl, c, bl), b, br)
-              else match splay a br with
+              else match splay_eq a br with
                 | leaf         → leaf (* TODO: undefined *)
                 | (al, x, xa) → (((cl, c, bl), b, al), x, xa)
+*)
 
-splay_noeq ∷ Ord α ⇒ α ⨯ Tree α → Tree α
-splay_noeq a t = match t with
+splay ∷ Ord α ⇒ α ⨯ Tree α → Tree α
+splay a t = match t with
   | leaf        → leaf
   | (cl, c, cr) → if a == c
     then (cl, c, cr)
@@ -48,12 +53,12 @@ splay_noeq a t = match t with
           else if a < b
             then match bl with
               | leaf            → (leaf, b, (br, c, cr))
-              | (bll, blx, blr) → match splay_noeq a (bll, blx, blr) with
+              | (bll, blx, blr) → match splay a (bll, blx, blr) with
                 | leaf         → leaf (* TODO: undefined *)
                 | (al, a', ar) → (al, a', (ar, b, (br, c, cr)))
             else match br with
               | leaf            → (bl, b, (leaf, c, cr))
-              | (brl, brx, brr) → match splay_noeq a (brl, brx, brr) with
+              | (brl, brx, brr) → match splay a (brl, brx, brr) with
                 | leaf         → leaf (* TODO: undefined *)
                 | (al, a', ar) → ((bl, b, al), a', (ar, c, cr))
       else match cr with
@@ -63,97 +68,129 @@ splay_noeq a t = match t with
           else if a < b
             then match bl with
               | leaf            → ((cl, c, leaf), b, br)
-              | (bll, blx, blr) → match splay_noeq a (bll, blx, blr) with
+              | (bll, blx, blr) → match splay a (bll, blx, blr) with
                 | leaf         → leaf (* TODO: undefined *)
                 | (al, a', ar) → ((cl, c, al), a', (ar, b, br))
             else match br with
               | leaf            → ((cl, c, bl), b, leaf)
-              | (brl, brx, brr) → match splay_noeq a (brl, brx, brr) with
+              | (brl, brx, brr) → match splay a (brl, brx, brr) with
                 | leaf         → leaf (* TODO: undefined *)
                 | (al, a', ar) → (((cl, c, bl), b, al), a', ar)
 
 (* We make the assumption that a < b < c and use this to simplify splay.
  * Since we do not need to compare elements anymore, we can drop the constraint
  * Ord α.
+ *
+ * This definition does not type anymore as of 2020-04-16 (type constraints).
  *)
-splay_zigzig ∷ Eq (Tree α) ⇒ α ⨯ Tree α → Tree α
-splay_zigzig a t = match t with
+(*
+splay_eq_zigzig ∷ Eq (Tree α) ⇒ α ⨯ Tree α → Tree α
+splay_eq_zigzig a t = match t with
     | leaf        → leaf
     | (cl, c, cr) → match cl with (* NOTE: We assume that a != c *)
         | leaf        → (leaf, c, cr)
         | (bl, b, br) → if bl == leaf (* NOTE: We assume that a != b *)
             then (bl, b, (br, c, cr))
-            else match splay_zigzig a bl with
+            else match splay_eq_zigzig a bl with
                 | leaf         → leaf (* TODO: undefined *)
                 | (al, a', ar) → (al, a', (ar, b, (br, c, cr)))
+ *)
 
-(* We make the assumption that a < b < c and use this to simplify splay_noeq.
+(* We make the assumption that a < b < c and use this to simplify splay.
  * Since we do not need to compare elements anymore, we can drop the constraint
  * Ord α.
+ *
+ * TODO: Should we also assume t != leaf and bl != leaf?
  *)
-splay_noeq_zigzig ∷ α ⨯ Tree α → Tree α
-splay_noeq_zigzig a t = match t with
+splay_zigzig ∷ α ⨯ Tree α → Tree α
+splay_zigzig a t = match t with
     | leaf        → leaf
     | (cl, c, cr) → match cl with (* NOTE: We assume that a != c *)
         | leaf        → (leaf, c, cr)
         | (bl, b, br) → match bl with (* NOTE: We assume that a != b *)
             | leaf            → (leaf, b, (br, c, cr))
-            | (bll, blx, blr) → match splay_noeq_zigzig a (bll, blx, blr) with
+            | (bll, blx, blr) → match splay_zigzig a (bll, blx, blr) with
                 | leaf         → leaf (* TODO: undefined *)
                 | (al, a', ar) → (al, a', (ar, b, (br, c, cr)))
 
-splay_max ∷ Eq (Tree α) ⇒ Tree α → Tree α
-splay_max t = match t with
+(* This variant of splay_max does not type anymore as of 2020-04-16
+ * (type constraints).
+ *)
+(*
+splay_max_eq ∷ Eq (Tree α) ⇒ Tree α → Tree α
+splay_max_eq t = match t with
     | leaf      → leaf
     | (l, b, r) → match r with
         | leaf         → (l, b, leaf)
         | (rl, c, rr) → if rr == leaf
             then ((l, b, rl), c, leaf)
-            else match splay_max rr with
+            else match splay_max_eq rr with
                 | leaf          → leaf (* TODO: undefined *)
                 | (rrl, x, xa)  → (((l, b, rl), c, rrl), x, xa)
+*)
 
-splay_max_noeq ∷ Tree α → Tree α
-splay_max_noeq t = match t with
+splay_max ∷ Tree α → Tree α
+splay_max t = match t with
     | leaf      → leaf
     | (l, b, r) → match r with
         | leaf         → (l, b, leaf)
         | (rl, c, rr) → match rr with
             | leaf            →  ((l, b, rl), c, leaf)
-            | (rrl, rrx, rrr) → match splay_max_noeq (rrl, rrx, rrr) with
+            | (rrl, rrx, rrr) → match splay_max (rrl, rrx, rrr) with
                 | leaf          → leaf (* TODO: undefined *)
                 | (rrl', x, xa) → (((l, b, rl), c, rrl'), x, xa)
 
-delete ∷ (Ord α, Eq (Tree α)) ⇒ α ⨯ Tree α → Tree α
-delete a t = if t == leaf
+(* This variant of delete does not type anymore as of 2020-04-16
+ * (type constraints).
+ *)
+(*
+delete_eq ∷ (Ord α, Eq (Tree α)) ⇒ α ⨯ Tree α → Tree α
+delete_eq a t = if t == leaf
   then leaf
-  else match splay a t with
+  else match splay_eq a t with
     | leaf       → leaf (* TODO: undefined *)
     | (l, a', r) → if a == a'
       then if l == leaf
         then r
-        else match splay_max l with
+        else match splay_max_eq l with
           | leaf        → leaf (* TODO: undefined *)
           | (l', m, r') → (l', m, r)
       else (l, a', r)
+*)
 
-delete_noeq ∷ Ord α ⇒ α ⨯ Tree α → Tree α
-delete_noeq a t = match t with
+delete ∷ Ord α ⇒ α ⨯ Tree α → Tree α
+delete a t = match t with
   | leaf         → leaf
-  | (tl, tx, tr) → match splay_noeq a (tl, tx, tr) with
+  | (tl, tx, tr) → match splay a (tl, tx, tr) with
     | leaf       → leaf (* TODO: undefined *)
     | (l, a', r) → if a == a'
       then match l with
         | leaf         → r
-        | (ll, lx, lr) → match splay_max_noeq (ll, lx, lr) with
+        | (ll, lx, lr) → match splay_max (ll, lx, lr) with
           | leaf          → leaf (* TODO: undefined *)
           | (ll', m, lr') → (ll', m, r)
       else (l, a', r)
 
-insert ∷ (Ord α, Eq (Tree α)) ⇒ α ⨯ Tree α → Tree α
-insert a t = if t == leaf
+(* This variant of insert does not type anymore as of 2020-04-16
+ * (type constraints).
+ *)
+(*
+insert_eq ∷ (Ord α, Eq (Tree α)) ⇒ α ⨯ Tree α → Tree α
+insert_eq a t = if t == leaf
   then (leaf, a, leaf)
-  else match splay a t with
+  else match splay_eq a t with
+    | leaf       → leaf (* TODO: undefined *)
+    | (l, a', r) → if a == a'
+      then (l, a, r)
+      else if a < a'
+        then (l, a, (leaf, a', r))
+        else ((l, a', leaf), a, r)
+*)
+
+insert ∷ Ord α ⇒ α ⨯ Tree α → Tree α
+insert a t = match t with
+  | leaf         → (leaf, a, leaf)
+  | (tl, tx, tr) → match splay a (tl, tx, tr) with
     | leaf       → leaf (* TODO: undefined *)
     | (l, a', r) → if a == a'
       then (l, a, r)
@@ -161,16 +198,21 @@ insert a t = if t == leaf
         then (l, a, (leaf, a', r))
         else ((l, a', leaf), a, r)
 
-contains ∷ (Ord α, Eq (Tree α)) ⇒ α ⨯ Tree α → Bool
+(* This variant of contains does not type anymore as of 2020-04-16
+ * (type constraints).
+ *)
+(*
+contains_eq ∷ (Ord α, Eq (Tree α)) ⇒ α ⨯ Tree α → Bool
+contains_eq a t = match t with
+  | leaf      → false
+  | (l, x, r) → match splay_eq a (l, x, r) with
+    | leaf         → false
+    | (l2, x2, r2) → (x2 == a)
+*)
+
+contains ∷ Ord α ⇒ α ⨯ Tree α → Bool
 contains a t = match t with
   | leaf      → false
   | (l, x, r) → match splay a (l, x, r) with
-    | leaf         → false
-    | (l2, x2, r2) → (x2 == a)
-
-contains_noeq ∷ Ord α ⇒ α ⨯ Tree α → Bool
-contains_noeq a t = match t with
-  | leaf      → false
-  | (l, x, r) → match splay_noeq a (l, x, r) with
     | leaf         → false
     | (l2, x2, r2) → (x2 == a)


### PR DESCRIPTION
We agreed to not support `(Eq (Tree α))` as a type constraint.